### PR TITLE
Add Lidingö and Östermalm service areas

### DIFF
--- a/api/submit-form.js
+++ b/api/submit-form.js
@@ -7,7 +7,7 @@ export default async function handler(req, res) {
     return res.status(405).send({ message: 'Only POST requests allowed' });
   }
 
-  const { name, email, tel, address, propertyType, cart, totalPrice } = req.body;
+  const { name, email, tel, address, message: customerMessage, propertyType, cart, totalPrice } = req.body;
 
   if (!name || !email || !cart || !totalPrice) {
     return res.status(400).json({ error: 'Missing required fields' });
@@ -18,7 +18,7 @@ E-post: ${email}
 Telefon: ${tel}
 Adress: ${address}
 Fastighetstyp: ${propertyType}
-
+${customerMessage ? `\nMeddelande från kund:\n${customerMessage}\n` : ''}
 Tjänster kunden valt:
 ${cart.map((item) => `${item.quantity} : ${item.description}`).join('\n')}
 Offertens värde: ${totalPrice} kr`;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Fönsterputs i Stockholm – Från 350 kr med RUT | Rutputs</title>
     <meta
       name="description"
-      content="Rutputs erbjuder professionell fönsterputsning Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden."
+      content="Rutputs erbjuder professionell fönsterputsning i Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden."
     />
     <link rel="canonical" href="https://www.rutputs.nu/" />
     <meta name="robots" content="index, follow" />

--- a/index.html
+++ b/index.html
@@ -3,28 +3,32 @@
   <head>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <title>
-      Fönsterputs norra Stockholm – Från 350 kr med RUT | Rutputs
-    </title>
+    <title>Fönsterputs i Stockholm – Från 350 kr med RUT | Rutputs</title>
     <meta
       name="description"
-      content="Rutputs erbjuder professionell fönsterputsning i norra Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden."
+      content="Rutputs erbjuder professionell fönsterputsning Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden."
     />
     <link rel="canonical" href="https://www.rutputs.nu/" />
     <meta name="robots" content="index, follow" />
-    <meta property="og:title" content="Fönsterputs norra Stockholm – Från 350 kr med RUT | Rutputs" />
+    <meta
+      property="og:title"
+      content="Fönsterputs i Stockholm – Från 350 kr med RUT | Rutputs"
+    />
     <meta
       property="og:description"
-      content="Rutputs erbjuder professionell fönsterputsning i norra Stockholm med RUT-avdrag. Från 350 kr. Se ditt pris direkt online."
+      content="Rutputs erbjuder professionell fönsterputsning i Stockholm med RUT-avdrag. Från 350 kr. Se ditt pris direkt online."
     />
     <meta property="og:url" content="https://www.rutputs.nu/" />
     <meta property="og:image" content="https://www.rutputs.nu/og-image.jpg" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Fönsterputs norra Stockholm – Från 350 kr med RUT | Rutputs" />
+    <meta
+      name="twitter:title"
+      content="Fönsterputs i Stockholm – Från 350 kr med RUT | Rutputs"
+    />
     <meta
       name="twitter:description"
-      content="Rutputs erbjuder professionell fönsterputsning i norra Stockholm med RUT-avdrag. Från 350 kr. Se ditt pris direkt online."
+      content="Rutputs erbjuder professionell fönsterputsning i Stockholm med RUT-avdrag. Från 350 kr. Se ditt pris direkt online."
     />
     <meta name="twitter:image" content="https://www.rutputs.nu/og-image.jpg" />
     <meta charset="utf-8" />
@@ -50,7 +54,7 @@
           "addressRegion": "Stockholm",
           "addressCountry": "SE"
         },
-        "description": "Professionell fönsterputsning i norra Stockholm. Från 350 kr med RUT-avdrag. Järfälla, Bromma, Kista, Solna, Sundbyberg, Sollentuna, Täby.",
+        "description": "Professionell fönsterputsning i Stockholm. Från 350 kr med RUT-avdrag. Järfälla, Bromma, Kista, Solna, Sundbyberg, Sollentuna, Täby.",
         "telephone": "+46734644604",
         "email": "kontakt@rutputs.nu",
         "priceRange": "från 350 SEK",
@@ -114,7 +118,7 @@
               "itemOffered": {
                 "@type": "Service",
                 "name": "Fönsterputsning för företag",
-                "description": "Professionell fönsterputsning för kontor och företagslokaler i norra Stockholm"
+                "description": "Professionell fönsterputsning för kontor och företagslokaler i Stockholm"
               }
             }
           ]
@@ -125,9 +129,20 @@
   <body>
     <!-- quasar:entry-point -->
     <noscript>
-      <div style="max-width:800px;margin:0 auto;padding:2rem;font-family:sans-serif">
-        <h1>Rutputs – Fönsterputsning i norra Stockholm</h1>
-        <p>Professionell fönsterputsning med RUT-avdrag från 350 kr. Vi täcker Järfälla, Bromma, Kista, Solna, Sundbyberg, Spånga, Sollentuna och Täby.</p>
+      <div
+        style="
+          max-width: 800px;
+          margin: 0 auto;
+          padding: 2rem;
+          font-family: sans-serif;
+        "
+      >
+        <h1>Rutputs – Fönsterputsning i Stockholm</h1>
+        <p>
+          Professionell fönsterputsning med RUT-avdrag från 350 kr. Vi täcker
+          Järfälla, Bromma, Kista, Solna, Sundbyberg, Spånga, Sollentuna och
+          Täby.
+        </p>
         <h2>Tjänster</h2>
         <ul>
           <li><a href="/pris">Prislista – Se ditt pris direkt</a></li>
@@ -146,7 +161,9 @@
         </ul>
         <h2>Kontakt</h2>
         <p>Telefon: <a href="tel:+46734644604">0734-64 46 04</a></p>
-        <p>E-post: <a href="mailto:kontakt@rutputs.nu">kontakt@rutputs.nu</a></p>
+        <p>
+          E-post: <a href="mailto:kontakt@rutputs.nu">kontakt@rutputs.nu</a>
+        </p>
         <p><a href="/integritetspolicy">Integritetspolicy</a></p>
       </div>
     </noscript>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,9 +1,9 @@
-# Rutputs – Fönsterputsning i norra Stockholm
+# Rutputs – Fönsterputsning i Stockholm
 
-> Professionell fönsterputsning med RUT-avdrag i norra Stockholm. Från 350 kr.
+> Professionell fönsterputsning med RUT-avdrag i Stockholm. Från 350 kr.
 
 ## Om Rutputs
-Rutputs erbjuder professionell fönsterputsning för privatpersoner och företag i norra Stockholm. Med RUT-avdrag (50% skattereduktion) börjar priset från 350 kr.
+Rutputs erbjuder professionell fönsterputsning för privatpersoner och företag i Stockholm. Med RUT-avdrag (50% skattereduktion) börjar priset från 350 kr.
 
 ## Tjänster
 - Fönsterputsning för privatpersoner (villor och lägenheter)

--- a/src/components/LandingComponent.vue
+++ b/src/components/LandingComponent.vue
@@ -7,7 +7,7 @@
           <img
             class="hero-shell__image"
             :src="randomPortraitImage"
-            alt="Professionell fönsterputsning i norra Stockholm"
+            alt="Professionell fönsterputsning i Stockholm"
             fetchpriority="high"
             decoding="async"
           >
@@ -17,8 +17,8 @@
           <span class="hero-kicker">Lokal fönsterputsare</span>
           <h1 class="hero-title">Rena fönster. Tydligt pris. Snabb bokning.</h1>
           <p class="hero-lead">
-            Rutputs hjälper hushåll i norra Stockholm med fönsterputsning som känns enkel att boka,
-            enkel att förstå och genomförd med jämn kvalitet från första kontakt till färdigt resultat. Du kan boka både enstaka puts och återkommande abonnemang.
+            Rutputs hjälper hushåll och företag i Stockholm med fönsterputsning till rimliga och tydliga priser och
+            som är enkel att boka. Alltid med samma höga kvalitet. Du kan boka både enstaka puts och återkommande abonnemang.
           </p>
           <div class="hero-actions">
             <q-btn class="text-black" label="Se vad det kostar" color="accent" unelevated @click="goToPriceList" />
@@ -40,7 +40,7 @@
       <section class="section-grid section-grid--two">
         <div class="editorial-panel editorial-panel--solid">
           <span class="section-kicker">Tydligt upplägg</span>
-          <h2 class="section-title">Fönsterputs i norra Stockholm utan onödigt krångel</h2>
+          <h2 class="section-title">Fönsterputs i Stockholm utan onödigt krångel</h2>
           <p class="section-text">
             Rutputs erbjuder professionell fönsterputsning för dig som vill ha rena fönster utan att jaga priser,
             ringa runt eller vänta på otydliga offerter. Du ser priset direkt, skickar din förfrågan och får snabb återkoppling.
@@ -119,16 +119,22 @@
         <span class="section-kicker">Områden</span>
         <h2 class="section-title">Vi täcker områden där närhet faktiskt gör skillnad</h2>
         <p class="section-text">
-          Rutputs fokuserar på norra Stockholm och närliggande områden där en lokal aktör ger snabbare bokning,
-          bättre planering och ett enklare upplägg för återkommande kunder. Välj din ort för att läsa mer om hur tjänsten passar där du bor.
+          Rutputs arbetar i stora delar av Stockholm med extra stark närvaro i norra Stockholm, där vi kan erbjuda kortare restider,
+          snabbare bokning och ett smidigare upplägg för återkommande kunder. Välj din ort för att läsa mer om hur tjänsten passar där du bor.
         </p>
-        <div class="mini-card-grid q-mt-lg">
-          <article v-for="item in areaLinks" :key="item.slug" class="mini-card">
-            <h3 class="mini-card__title">{{ item.name }}</h3>
-            <p class="mini-card__text q-mb-sm">Lokal fönsterputsning med tydligt pris och bokning online.</p>
-            <router-link :to="'/omrade/' + item.slug" class="text-accent text-weight-bold">Läs om {{ item.name }}</router-link>
-          </article>
+        <div class="area-link-grid q-mt-lg">
+          <router-link
+            v-for="item in areaLinks"
+            :key="item.slug"
+            :to="'/omrade/' + item.slug"
+            class="area-link text-accent text-weight-bold"
+          >
+            {{ item.name }}
+          </router-link>
         </div>
+        <p class="section-text" style="margin-top: 2rem">
+          Bor du i ett annat område? Skicka in en förfrågan ändå så ser vi om vi kan hjälpa dig.
+        </p>
       </section>
 
       <section class="cta-band">

--- a/src/components/PriceListComponent.vue
+++ b/src/components/PriceListComponent.vue
@@ -256,6 +256,15 @@
                       val => val !== null && val !== '' || 'Vänligen fyll i din e-postadress',
                       val => /.+@.+\..+/.test(val) || 'Ogiltig e-postadress']"
                   />
+                  <q-input
+                    v-model="form.message"
+                    filled
+                    type="textarea"
+                    label="Meddelande"
+                    hint="T.ex. när du vill ha putsningen utförd eller annat du vill meddela"
+                    autogrow
+                    maxlength="500"
+                  />
 
                   <!-- Terms and conditions toggle -->
                   <q-toggle
@@ -483,6 +492,7 @@ export default defineComponent({
         tel: '',
         address: '',
         email: '',
+        message: '',
         termsAccepted: false,
         totalPrice: 0
       },
@@ -669,6 +679,7 @@ export default defineComponent({
         email: this.form.email,
         tel: this.form.tel,
         address: this.form.address,
+        message: this.form.message,
         propertyType: this.form.propertyType,
         cart: this.cart,
         totalPrice: this.form.totalPrice
@@ -707,6 +718,7 @@ export default defineComponent({
         tel: '',
         address: '',
         email: '',
+        message: '',
         termsAccepted: false,
         totalPrice: this.form.totalPrice
       };

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -201,6 +201,24 @@ a
   grid-template-columns: repeat(4, minmax(0, 1fr))
   gap: 1rem
 
+.area-link-grid
+  display: flex
+  flex-wrap: wrap
+  gap: 0.75rem
+
+.area-link
+  display: inline-block
+  padding: 0.55rem 1.1rem
+  border-radius: var(--radius-md)
+  border: 1px solid rgba(69, 90, 100, 0.15)
+  background: rgba(255, 255, 255, 0.66)
+  font-size: 1rem
+  text-decoration: none
+  transition: background 0.15s, border-color 0.15s
+  &:hover
+    background: rgba(255, 97, 1, 0.08)
+    border-color: $accent
+
 .mini-card
   border-radius: var(--radius-md)
   padding: 1rem

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -218,6 +218,11 @@ a
   &:hover
     background: rgba(255, 97, 1, 0.08)
     border-color: $accent
+  &:focus-visible
+    background: rgba(255, 97, 1, 0.08)
+    border-color: $accent
+    outline: 2px solid $accent
+    outline-offset: 2px
 
 .mini-card
   border-radius: var(--radius-md)

--- a/src/data/areas.ts
+++ b/src/data/areas.ts
@@ -35,5 +35,13 @@ export const areas: AreaLink[] = [
   {
     slug: 'taby',
     name: 'Täby',
+  },
+  {
+    slug: 'lidingo',
+    name: 'Lidingö',
+  },
+  {
+    slug: 'ostermalm',
+    name: 'Östermalm',
   }
 ];

--- a/src/data/seo-content.js
+++ b/src/data/seo-content.js
@@ -17,7 +17,7 @@ const siteSeoContent = {
       {
         question: 'Vilka områden täcker Rutputs?',
         answer:
-          'Rutputs täcker främst norra Stockholm: Järfälla, Bromma, Kista, Solna, Sundbyberg, Spånga, Sollentuna och Täby. Men vi hjälper även kunder i andra områden. Fyll i formuläret för att se hur vi kan hjälpa dig!',
+          'Rutputs täcker främst norra Stockholm: Järfälla, Bromma, Kista, Solna, Sundbyberg, Spånga, Sollentuna och Täby. Vi arbetar även på Lidingö och Östermalm. Fyll i formuläret för att se hur vi kan hjälpa dig!',
         links: [
           { label: 'Järfälla', to: '/omrade/jarfalla' },
           { label: 'Bromma', to: '/omrade/bromma' },
@@ -27,6 +27,8 @@ const siteSeoContent = {
           { label: 'Spånga', to: '/omrade/spanga' },
           { label: 'Sollentuna', to: '/omrade/sollentuna' },
           { label: 'Täby', to: '/omrade/taby' },
+          { label: 'Lidingö', to: '/omrade/lidingo' },
+          { label: 'Östermalm', to: '/omrade/ostermalm' },
         ],
       },
       {
@@ -360,6 +362,60 @@ const siteSeoContent = {
         },
         {
           question: 'Hur får jag pris för fönsterputs i Täby?',
+          answer:
+            'Du fyller i formuläret på prissidan för att se pris direkt. Därefter bekräftas bokningen i nästa steg.',
+        },
+      ],
+    },
+    {
+      slug: 'lidingo',
+      name: 'Lidingö',
+      title: 'Fönsterputs Lidingö – Från 350 kr med RUT-avdrag | Rutputs',
+      description:
+        'Professionell fönsterputsning på Lidingö med RUT-avdrag. Från 350 kr. Vi täcker Lidingö centrum, Brevik, Rudboda och Herserud. Boka enkelt online!',
+      content:
+        'På Lidingö erbjuder vi professionell fönsterputsning för villor, radhus och lägenheter. Med många vackra bostäder och stora fönsterpartier är Lidingö ett område där rena fönster verkligen gör skillnad. Vi arbetar i hela kommunen och erbjuder både enstaka putsningar och återkommande upplägg för dig som vill ha ett smidigt och pålitligt resultat.',
+      districts: ['Lidingö centrum', 'Brevik', 'Rudboda', 'Herserud'],
+      faq: [
+        {
+          question: 'Vilka delar av Lidingö täcker ni?',
+          answer:
+            'Vi arbetar i hela Lidingö kommun, bland annat i Lidingö centrum, Brevik, Rudboda och Herserud samt övriga delar av ön.',
+        },
+        {
+          question: 'Vad kostar fönsterputs på Lidingö?',
+          answer:
+            'Priset börjar från 350 kr efter RUT-avdrag. Det exakta priset beror på antal fönster och bostadstyp. Använd vår priskalkylator för att se ditt pris direkt.',
+        },
+        {
+          question: 'Hur bokar jag fönsterputs på Lidingö?',
+          answer:
+            'Du fyller i prisformuläret online för att se ditt pris direkt. Därefter återkommer vi för att bekräfta bokning och tid.',
+        },
+      ],
+    },
+    {
+      slug: 'ostermalm',
+      name: 'Östermalm',
+      title: 'Fönsterputs Östermalm – Från 350 kr med RUT-avdrag | Rutputs',
+      description:
+        'Fönsterputsning på Östermalm med RUT-avdrag från 350 kr. Vi täcker Gärdet, Djurgården, Lärkstan och Hjorthagen. Boka enkelt online!',
+      content:
+        'Östermalm med sina eleganta fasader, stora fönster och klassiska bostäder är ett område där professionell fönsterputsning gör stor skillnad. Vi hjälper privatpersoner i hela stadsdelen med noggrann och smidig service, oavsett om du bor i lägenhet, radhus eller villa. Boka enstaka puts eller återkommande abonnemang.',
+      districts: ['Gärdet', 'Djurgården', 'Lärkstan', 'Hjorthagen'],
+      faq: [
+        {
+          question: 'Vilka delar av Östermalm täcker ni?',
+          answer:
+            'Vi arbetar bland annat på Gärdet, Djurgården, i Lärkstan och Hjorthagen samt i övriga delar av Östermalm.',
+        },
+        {
+          question: 'Passar tjänsten lägenheter på Östermalm?',
+          answer:
+            'Ja, vi hjälper kunder i alla typer av bostäder – lägenheter, radhus och villor. Upplägget anpassas efter bostadens storlek och antal fönster.',
+        },
+        {
+          question: 'Hur får jag pris för fönsterputs på Östermalm?',
           answer:
             'Du fyller i formuläret på prissidan för att se pris direkt. Därefter bekräftas bokningen i nästa steg.',
         },

--- a/src/data/seo-content.js
+++ b/src/data/seo-content.js
@@ -1,11 +1,11 @@
 const siteSeoContent = {
   home: {
-    title: 'Fönsterputs norra Stockholm – Från 350 kr med RUT | Rutputs',
+    title: 'Fönsterputs i Stockholm – Från 350 kr med RUT | Rutputs',
     description:
-      'Rutputs erbjuder professionell fönsterputsning i norra Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden. Boka online!',
-    bodyTitle: 'Fönsterputs i norra Stockholm',
+      'Rutputs erbjuder professionell fönsterputsning i Stockholm med RUT-avdrag. Från 350 kr. Vi täcker Järfälla, Sundbyberg, Solna, Spånga med flera områden. Boka online!',
+    bodyTitle: 'Fönsterputs i Stockholm',
     bodyIntro:
-      'Rutputs erbjuder professionell fönsterputsning i norra Stockholm för privatpersoner och företag. Med RUT-avdrag börjar priset från 350 kr och du kan se ditt pris direkt online. Du kan boka både enstaka puts och återkommande abonnemang.',
+      'Rutputs erbjuder professionell fönsterputsning i Stockholm för privatpersoner och företag. Med RUT-avdrag börjar priset från 350 kr och du kan se ditt pris direkt online. Du kan boka både enstaka puts och återkommande abonnemang.',
     faq: [
       {
         question: 'Vad kostar fönsterputsning med RUT-avdrag?',
@@ -46,7 +46,7 @@ const siteSeoContent = {
       {
         question: 'Putsar ni även företagsfönster?',
         answer:
-          'Ja, vi erbjuder professionell fönsterputsning för kontor och företagslokaler i norra Stockholm. Kontakta oss för en offert.',
+          'Ja, vi erbjuder professionell fönsterputsning för kontor och företagslokaler i stora delar av Stockholm. Kontakta oss för en offert.',
         linkLabel: 'Läs mer om fönsterputs för företag',
         linkTo: '/foretag',
       },
@@ -60,7 +60,7 @@ const siteSeoContent = {
   company: {
     title: 'Fönsterputs för företag i Stockholm | Rutputs',
     description:
-      'Professionell fönsterputs för företag i Stockholm och norra Stockholm. Flexibla avtal, regelbunden service och rena fönster för kontor, lokaler och skyltfönster.',
+      'Professionell fönsterputs för företag i Stockholm. Flexibla avtal, regelbunden service och rena fönster för kontor, lokaler och skyltfönster.',
     bodyTitle: 'Fönsterputs för företag',
     bodyIntro:
       'Rutputs hjälper företag, kontor, butiker och mindre fastigheter i Stockholm med professionell fönsterputsning. Tjänsten kan anpassas som abonnemang eller punktinsats för återkommande intervaller, skyltfönster och tydliga serviceupplägg.',
@@ -78,7 +78,7 @@ const siteSeoContent = {
       {
         question: 'Arbetar ni bara i norra Stockholm?',
         answer:
-          'Fokus ligger på norra Stockholm, där Rutputs redan arbetar löpande men vi är inte omöjliga. Fyll i formuläret så ser vi om vi kan hjälpa dig oavsett var du befinner dig.',
+          'Nej. Vi utgår från norra Stockholm, där vi redan arbetar löpande men vi är inte omöjliga. Fyll i formuläret så ser vi om vi kan hjälpa dig oavsett var du befinner dig.',
       },
       {
         question: 'Hur får vi en offert?',
@@ -105,7 +105,7 @@ const siteSeoContent = {
   price: {
     title: 'Prislista – Fönsterputsning med RUT-avdrag | Rutputs',
     description:
-      'Se priser för fönsterputsning i norra Stockholm. Räkna ut ditt pris direkt – från 350 kr med RUT-avdrag. Enkel offertförfrågan online.',
+      'Se priser för fönsterputsning i Stockholm. Räkna ut ditt pris direkt – från 350 kr med RUT-avdrag. Enkel offertförfrågan online.',
     bodyTitle: 'Prislista för fönsterputsning',
     bodyIntro:
       'På prissidan kan du räkna ut vad fönsterputsningen kostar utifrån din bostad och antal fönster. Priset börjar från 350 kr efter RUT-avdrag.',

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -11,7 +11,7 @@
           />
           <div class="top-nav__brand-copy">
             <span class="top-nav__eyebrow">Rutputs</span>
-            <span class="top-nav__headline">Fönsterputs i norra Stockholm</span>
+            <span class="top-nav__headline">Fönsterputs i Stockholm</span>
           </div>
         </router-link>
 
@@ -38,7 +38,7 @@
             <a href="/" @click.prevent="goToLanding()" class="brand-banner__link">
               <img
                 class="brand-banner__image"
-                alt="Rutputs – Fönsterputsning i norra Stockholm"
+                alt="Rutputs – Fönsterputsning Stockholm"
                 src="/icons/main_logo.png"
                 width="900"
                 height="200"

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -38,7 +38,7 @@
             <a href="/" @click.prevent="goToLanding()" class="brand-banner__link">
               <img
                 class="brand-banner__image"
-                alt="Rutputs – Fönsterputsning Stockholm"
+                alt="Rutputs – Fönsterputsning i Stockholm"
                 src="/icons/main_logo.png"
                 width="900"
                 height="200"


### PR DESCRIPTION
## Summary
Expanded Rutputs' service coverage to include two new areas: Lidingö and Östermalm. This includes updating service area information, adding dedicated landing pages with SEO content, and updating the areas registry.

## Changes Made
- **Updated service area description**: Modified the main FAQ answer to reflect that Rutputs now works in Lidingö and Östermalm, replacing the generic "other areas" language with specific area names
- **Added area links**: Included navigation links to the new Lidingö and Östermalm service pages in the main FAQ section
- **Created Lidingö landing page**: Added complete SEO content including title, meta description, service area details, district listings (Lidingö centrum, Brevik, Rudboda, Herserud), and FAQ section
- **Created Östermalm landing page**: Added complete SEO content including title, meta description, service area details, district listings (Gärdet, Djurgården, Lärkstan, Hjorthagen), and FAQ section
- **Updated areas registry**: Added both new areas to the `areas.ts` file for proper routing and navigation

## Implementation Details
- Both new area pages follow the existing content structure and formatting conventions
- SEO titles and descriptions are optimized with relevant keywords and pricing information
- Each area includes 3 FAQ questions addressing common customer inquiries (coverage, pricing, booking)
- District-specific information helps with local SEO and customer targeting

https://claude.ai/code/session_01Vy2srCnaFiPeM4BsJtr6FB