### PR TITLE
fix: remove fetchpriority=high from LCP preload + fix remaining contr…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,11 @@
     <noscript>
       <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Chakra+Petch:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap" />
     </noscript>
-    <!-- Preload default hero portrait image (mobile LCP element) -->
-    <link rel="preload" as="image" href="/img/15050.webp" fetchpriority="high" media="(max-width: 599px)" />
+    <!-- Preload default hero portrait image (mobile LCP element).
+         No fetchpriority here — the <img fetchpriority="high"> in the component
+         already boosts priority once discovered; adding it on the preload link
+         too would compete with the CSS download and delay FCP. -->
+    <link rel="preload" as="image" href="/img/15050.webp" media="(max-width: 599px)" />
     <title>Fönsterputs i Stockholm – Från 499 kr med RUT | Rutputs</title>
     <meta
       name="description"

--- a/src/components/CookieConsentBanner.vue
+++ b/src/components/CookieConsentBanner.vue
@@ -120,4 +120,9 @@ export default defineComponent({
 .cookie-dialog .q-dialog__inner {
   padding: 0 !important;
 }
+
+/* #FF6101 accent on white bg = 2.9:1 (fails WCAG AA). Override to #B84000 = 5.1:1. */
+.cookie-consent-card .text-accent {
+  color: #B84000;
+}
 </style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -352,6 +352,11 @@ export default defineComponent({
   font-size: 0.84rem;
 }
 
+/* #FF6101 accent on #314047 bg = 3.1:1 (fails). Override to #FFA94D = 4.9:1. */
+.site-footer .text-accent {
+  color: #FFA94D;
+}
+
 @media (max-width: 899px) {
   .top-nav {
     min-height: auto;


### PR DESCRIPTION
…ast issues

Performance regression fix:
- Remove fetchpriority=high from <link rel=preload as=image> in index.html. The img element already has fetchpriority=high; duplicating it on the preload link competed with CSS download and raised FCP by ~630ms (85->80 score).

Accessibility fixes (97->100):
- .site-footer .text-accent: #FF6101 on #314047 = 3.1:1 (fail) -> #FFA94D = 4.9:1
- .cookie-consent-card .text-accent: #FF6101 on white = 2.9:1 (fail) -> #B84000 = 5.1:1