### PR TITLE
feat(form): collect full postal address in quote form

### DIFF
--- a/api/kontakt-handler.js
+++ b/api/kontakt-handler.js
@@ -17,6 +17,8 @@ const schema = z.object({
   email: z.string().trim().email().max(200),
   tel: z.string().trim().min(6).max(60),
   address: z.string().trim().max(200).optional().or(z.literal('')),
+  postalCode: z.string().trim().max(20).optional().or(z.literal('')),
+  city: z.string().trim().max(100).optional().or(z.literal('')),
   propertyType: z.enum(['house', 'apartment']),
   windowCount: z.number().int().positive(),
   cleaningSides: cleaningSidesSchema,
@@ -35,6 +37,12 @@ function formatCleaningSides(sides) {
   }
 
   return 'Utsida + Insida + Mellan';
+}
+
+function formatPostalAddress({ address, postalCode, city }) {
+  const postalLine = [postalCode, city].filter(Boolean).join(' ').trim();
+
+  return [address, postalLine].filter(Boolean).join(', ');
 }
 
 function getSesErrorDetails(error) {
@@ -84,6 +92,7 @@ export default async function handleKontaktRequest(req, res) {
   const propertyTypeLabel =
     parsed.data.propertyType === 'house' ? 'Villa/Radhus' : 'Lägenhet';
   const cleaningSidesLabel = formatCleaningSides(parsed.data.cleaningSides);
+  const postalAddress = formatPostalAddress(parsed.data);
 
   const requestLabel = `[kontakt:${randomUUID()}]`;
   const detailedMessage = [
@@ -92,7 +101,7 @@ export default async function handleKontaktRequest(req, res) {
     `Namn: ${parsed.data.name}`,
     `E-post: ${parsed.data.email}`,
     `Telefon: ${parsed.data.tel}`,
-    `Adress: ${parsed.data.address || '-'}`,
+    `Adress: ${postalAddress || '-'}`,
     `Bostadstyp: ${propertyTypeLabel}`,
     `Antal fönster: ${parsed.data.windowCount}`,
     `Sidor: ${cleaningSidesLabel}`,
@@ -127,6 +136,9 @@ export default async function handleKontaktRequest(req, res) {
           page: typeof req.headers.referer === 'string' ? req.headers.referer : null,
           submitted_at: new Date().toISOString(),
           address: parsed.data.address || null,
+          postal_code: parsed.data.postalCode || null,
+          city: parsed.data.city || null,
+          postal_address: postalAddress || null,
           property_type: parsed.data.propertyType,
           window_count: parsed.data.windowCount,
           cleaning_sides: parsed.data.cleaningSides,

--- a/api/kontakt-handler.js
+++ b/api/kontakt-handler.js
@@ -12,13 +12,30 @@ const ses =
 
 const cleaningSidesSchema = z.enum(['outside', 'both', 'all']);
 
+// Svenskt postnummer, med eller utan mellanslag: "17731" eller "177 31"
+const postalCodeSchema = z
+  .string()
+  .trim()
+  .regex(/^\d{3}\s?\d{2}$/)
+  .optional()
+  .or(z.literal(''));
+
+// Postort: bokstäver, mellanslag, bindestreck och apostrof
+const citySchema = z
+  .string()
+  .trim()
+  .max(100)
+  .regex(/^\p{L}[\p{L}\s'’-]*$/u)
+  .optional()
+  .or(z.literal(''));
+
 const schema = z.object({
   name: z.string().trim().min(1).max(200),
   email: z.string().trim().email().max(200),
   tel: z.string().trim().min(6).max(60),
   address: z.string().trim().max(200).optional().or(z.literal('')),
-  postalCode: z.string().trim().max(20).optional().or(z.literal('')),
-  city: z.string().trim().max(100).optional().or(z.literal('')),
+  postalCode: postalCodeSchema,
+  city: citySchema,
   propertyType: z.enum(['house', 'apartment']),
   windowCount: z.number().int().positive(),
   cleaningSides: cleaningSidesSchema,
@@ -37,6 +54,13 @@ function formatCleaningSides(sides) {
   }
 
   return 'Utsida + Insida + Mellan';
+}
+
+// Skriv alltid postnumret som "123 45", oavsett hur det skickades in
+function normalizePostalCode(postalCode) {
+  const digits = (postalCode || '').replace(/\D/g, '');
+
+  return digits.length === 5 ? `${digits.slice(0, 3)} ${digits.slice(3)}` : '';
 }
 
 function formatPostalAddress({ address, postalCode, city }) {
@@ -92,7 +116,8 @@ export default async function handleKontaktRequest(req, res) {
   const propertyTypeLabel =
     parsed.data.propertyType === 'house' ? 'Villa/Radhus' : 'Lägenhet';
   const cleaningSidesLabel = formatCleaningSides(parsed.data.cleaningSides);
-  const postalAddress = formatPostalAddress(parsed.data);
+  const postalCode = normalizePostalCode(parsed.data.postalCode);
+  const postalAddress = formatPostalAddress({ ...parsed.data, postalCode });
 
   const requestLabel = `[kontakt:${randomUUID()}]`;
   const detailedMessage = [
@@ -136,7 +161,7 @@ export default async function handleKontaktRequest(req, res) {
           page: typeof req.headers.referer === 'string' ? req.headers.referer : null,
           submitted_at: new Date().toISOString(),
           address: parsed.data.address || null,
-          postal_code: parsed.data.postalCode || null,
+          postal_code: postalCode || null,
           city: parsed.data.city || null,
           postal_address: postalAddress || null,
           property_type: parsed.data.propertyType,

--- a/src/components/PriceListComponent.vue
+++ b/src/components/PriceListComponent.vue
@@ -218,9 +218,47 @@
                     v-model="form.address"
                     filled
                     type="text"
-                    hint="Adress"
-                    label="Adress"
+                    label="Gatuadress *"
+                    hint="T.ex. Storgatan 12"
+                    autocomplete="street-address"
+                    lazy-rules
+                    :rules="[
+                      val => val !== null && val !== '' || 'Vänligen fyll i din gatuadress',
+                      val => val && val.trim().length > 2 || 'Vänligen fyll i en korrekt gatuadress']"
                   />
+                  <div class="address-row">
+                    <div class="address-row__col address-row__col--postal">
+                      <q-input
+                        v-model="form.postalCode"
+                        filled
+                        type="text"
+                        inputmode="numeric"
+                        label="Postnummer *"
+                        hint="T.ex. 177 31"
+                        mask="### ##"
+                        unmasked-value
+                        autocomplete="postal-code"
+                        lazy-rules
+                        :rules="[
+                          val => val !== null && val !== '' || 'Vänligen fyll i ditt postnummer',
+                          val => /^\d{5}$/.test((val || '').replace(/\s/g, '')) || 'Postnumret ska bestå av 5 siffror']"
+                      />
+                    </div>
+                    <div class="address-row__col">
+                      <q-input
+                        v-model="form.city"
+                        filled
+                        type="text"
+                        label="Postort *"
+                        hint="T.ex. Järfälla"
+                        autocomplete="address-level2"
+                        lazy-rules
+                        :rules="[
+                          val => val !== null && val !== '' || 'Vänligen fyll i din postort',
+                          val => val && val.trim().length > 1 || 'Vänligen fyll i en korrekt postort']"
+                      />
+                    </div>
+                  </div>
                   <q-input
                     v-model="form.email"
                     filled
@@ -447,6 +485,8 @@ export default defineComponent({
         name: '',
         tel: '',
         address: '',
+        postalCode: '',
+        city: '',
         email: '',
         message: '',
         website: '',
@@ -464,6 +504,13 @@ export default defineComponent({
       step: ref(1),
       areas,
     }
+  },
+  computed: {
+    // Postnummer sparas utan mellanslag, men skickas i formatet "123 45"
+    formattedPostalCode(): string {
+      const digits = (this.form.postalCode || '').replace(/\D/g, '');
+      return digits.length === 5 ? `${digits.slice(0, 3)} ${digits.slice(3)}` : digits;
+    },
   },
   methods: {
     getCleaningSidesLabel(sides: CleaningSides): string {
@@ -567,6 +614,8 @@ export default defineComponent({
         email: this.form.email,
         tel: this.form.tel,
         address: this.form.address,
+        postalCode: this.formattedPostalCode,
+        city: this.form.city,
         message: this.form.message,
         website: this.form.website,
         propertyType: this.form.propertyType,
@@ -603,6 +652,8 @@ export default defineComponent({
       this.form.name = '';
       this.form.tel = '';
       this.form.address = '';
+      this.form.postalCode = '';
+      this.form.city = '';
       this.form.email = '';
       this.form.message = '';
       this.form.website = '';
@@ -641,6 +692,27 @@ export default defineComponent({
 .property-type-group legend {
   margin-bottom: 0.6rem;
   font-weight: 600;
+}
+
+.address-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.address-row__col {
+  flex: 1 1 100%;
+  min-width: 0;
+}
+
+@media (min-width: 600px) {
+  .address-row__col {
+    flex: 1 1 0;
+  }
+
+  .address-row__col--postal {
+    flex: 0 0 40%;
+  }
 }
 
 .honeypot-field {

--- a/src/components/PriceListComponent.vue
+++ b/src/components/PriceListComponent.vue
@@ -255,7 +255,8 @@
                         lazy-rules
                         :rules="[
                           val => val !== null && val !== '' || 'Vänligen fyll i din postort',
-                          val => val && val.trim().length > 1 || 'Vänligen fyll i en korrekt postort']"
+                          val => val && val.trim().length > 1 || 'Vänligen fyll i en korrekt postort',
+                          val => /^\p{L}[\p{L}\s'’-]*$/u.test((val || '').trim()) || 'Postorten får bara innehålla bokstäver']"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Split the optional "Adress" field into required gatuadress, postnummer
and postort so every quote request includes the complete postal address.

- Postnummer uses a "### ##" mask and is sent as "123 45"
- Postnummer and postort share a row on desktop, stack on mobile
- Reset clears the new fields
- kontakt-handler accepts postalCode/city, prints the full address in the
  lead e-mail and adds postal_code, city and postal_address to the CRM
  metadata (fields stay optional server side for legacy callers)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017buxTaKVSBVMF5vjhK1MZn