### PR TITLE
Lägg till tre Google-omdömen och gör omdömessektionen till en karusell

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
         "aggregateRating": {
           "@type": "AggregateRating",
           "ratingValue": "5.0",
-          "reviewCount": "2",
+          "reviewCount": "5",
           "bestRating": "5",
           "worstRating": "1"
         },

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -45,7 +45,7 @@ function buildLocalBusinessSchema() {
     },
     review: reviews.map((r) => ({
       '@type': 'Review',
-      author: { '@type': r.authorType || 'Person', name: r.author },
+      author: { '@type': r.authorType ?? 'Person', name: r.author },
       datePublished: r.date,
       reviewBody: r.text,
       reviewRating: {

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import siteSeoContent from '../src/data/seo-content.js';
 import guides from '../src/data/guides-content.js';
 import business from '../src/data/business.js';
-import reviews from '../src/data/reviews-content.js';
+import reviews, { ratingValue, reviewCount } from '../src/data/reviews-content.js';
 
 const baseUrl = 'https://www.rutputs.nu';
 const distDir = path.resolve('dist/spa');
@@ -38,8 +38,8 @@ function buildLocalBusinessSchema() {
     areaServed: areas.map((a) => ({ '@type': 'City', name: a.name })),
     aggregateRating: {
       '@type': 'AggregateRating',
-      ratingValue: String(business.aggregateRating.ratingValue),
-      reviewCount: String(business.aggregateRating.reviewCount),
+      ratingValue: ratingValue.toFixed(1),
+      reviewCount: String(reviewCount),
       bestRating: '5',
       worstRating: '1',
     },

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -3,6 +3,7 @@ import path from 'node:path';
 import siteSeoContent from '../src/data/seo-content.js';
 import guides from '../src/data/guides-content.js';
 import business from '../src/data/business.js';
+import reviews from '../src/data/reviews-content.js';
 
 const baseUrl = 'https://www.rutputs.nu';
 const distDir = path.resolve('dist/spa');
@@ -42,6 +43,18 @@ function buildLocalBusinessSchema() {
       bestRating: '5',
       worstRating: '1',
     },
+    review: reviews.map((r) => ({
+      '@type': 'Review',
+      author: { '@type': r.authorType || 'Person', name: r.author },
+      datePublished: r.date,
+      reviewBody: r.text,
+      reviewRating: {
+        '@type': 'Rating',
+        ratingValue: String(r.rating),
+        bestRating: '5',
+        worstRating: '1',
+      },
+    })),
     hasOfferCatalog: {
       '@type': 'OfferCatalog',
       name: 'Fönsterputsningstjänster',
@@ -125,6 +138,16 @@ const buildLinkListHtml = (items = []) =>
 const buildTextListHtml = (items = [], tagName = 'ul') =>
   `<${tagName}>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</${tagName}>`;
 
+// Omdömena renderas klientsida av Vue, men aggregateRating i den strukturerade
+// datan kräver att recensionsinnehållet också syns i den prerenderade HTML:en.
+const buildReviewsHtml = (items = []) =>
+  `<ul>${items
+    .map(
+      (item) =>
+        `<li>${escapeHtml(item.rating)} av 5 stjärnor: &ldquo;${escapeHtml(item.text)}&rdquo; – ${escapeHtml(item.author)}</li>`
+    )
+    .join('')}</ul>`;
+
 const buildDistrictsHtml = (districts = []) => `<p>${districts.map((district) => escapeHtml(district)).join(', ')}</p>`;
 
 const buildFaqSchema = (faq = []) => ({
@@ -151,6 +174,10 @@ const pages = [
       {
         heading: 'Områden vi täcker',
         html: buildLinkListHtml(areas),
+      },
+      {
+        heading: 'Kundomdömen',
+        html: buildReviewsHtml(reviews),
       },
       {
         heading: 'Vanliga frågor',

--- a/src/components/LandingComponent.vue
+++ b/src/components/LandingComponent.vue
@@ -129,7 +129,7 @@
             ref="reviewTrack"
             class="review-carousel__track"
             tabindex="0"
-            @scroll.passive="measureReviews"
+            @scroll.passive="scheduleReviewMeasure"
           >
             <article v-for="review in reviewsData.reviews" :key="review.author + review.date" class="review-card">
               <div class="review-card__stars" role="img" :aria-label="review.rating + ' av 5 stjärnor'">
@@ -430,20 +430,29 @@ export default defineComponent({
     // korten går att svepa mellan även utan JS. Pilarna och punkterna nedan
     // är bara ett tillgängligt komplement som döljs när allt redan får plats.
     const reviewTrack = ref<HTMLElement | null>(null);
+    let reviewFrameId = 0;
     const reviewsOverflow = ref(false);
     const activeReviewIndex = ref(0);
     const reviewPageCount = ref(0);
     const canScrollReviewsPrev = ref(false);
     const canScrollReviewsNext = ref(false);
 
-    // Ett "steg" är ett kort plus mellanrummet till nästa kort.
+    // Ett "steg" är ett kort plus mellanrummet till nästa kort. Kortbredden är
+    // procentuell och ändras bara när spåret gör det, så värdet cachas i
+    // stället för att läsas ur layouten vid varje scroll. Nollställs vid resize.
+    let cachedReviewStep = 0;
+
     const reviewStep = (track: HTMLElement) => {
+      if (cachedReviewStep > 0) {
+        return cachedReviewStep;
+      }
       const card = track.querySelector<HTMLElement>('.review-card');
       if (!card) {
         return 0;
       }
       const gap = parseFloat(window.getComputedStyle(track).columnGap) || 0;
-      return card.offsetWidth + gap;
+      cachedReviewStep = card.offsetWidth + gap;
+      return cachedReviewStep;
     };
 
     const measureReviews = () => {
@@ -465,6 +474,19 @@ export default defineComponent({
       const step = reviewStep(track);
       reviewPageCount.value = step > 0 ? Math.round(maxScroll / step) + 1 : 0;
       activeReviewIndex.value = step > 0 ? Math.round(track.scrollLeft / step) : 0;
+    };
+
+    // Scroll-eventet kan komma flera gånger per bildruta. Mätningen läser
+    // layout, så den samlas ihop till en gång per ruta – samma mönster som
+    // parallaxen ovan.
+    const scheduleReviewMeasure = () => {
+      if (reviewFrameId) {
+        return;
+      }
+      reviewFrameId = window.requestAnimationFrame(() => {
+        reviewFrameId = 0;
+        measureReviews();
+      });
     };
 
     const scrollBehavior = (): ScrollBehavior =>
@@ -519,6 +541,7 @@ export default defineComponent({
     // vid resize för att pilarna ska stämma.
     const onResize = () => {
       scheduleParallaxUpdate();
+      cachedReviewStep = 0;
       measureReviews();
     };
 
@@ -553,6 +576,10 @@ export default defineComponent({
         window.cancelAnimationFrame(animationFrameId);
       }
 
+      if (reviewFrameId) {
+        window.cancelAnimationFrame(reviewFrameId);
+      }
+
       if (portraitTimerId) {
         if ('cancelIdleCallback' in window) {
           window.cancelIdleCallback(portraitTimerId as number);
@@ -581,7 +608,7 @@ export default defineComponent({
       reviewPageCount,
       canScrollReviewsPrev,
       canScrollReviewsNext,
-      measureReviews,
+      scheduleReviewMeasure,
       scrollReviews,
       goToReview
     };

--- a/src/components/LandingComponent.vue
+++ b/src/components/LandingComponent.vue
@@ -465,9 +465,24 @@ export default defineComponent({
       // Punkterna motsvarar nåbara scrollpositioner, inte antalet kort. Visas
       // tre kort samtidigt finns bara tre positioner att gå till, och då ska
       // det vara tre punkter – annars pekar de sista punkterna på samma läge.
+      //
+      // Ceil, inte round: går maxScroll inte jämnt upp i steglängden krävs en
+      // punkt till för den sista biten, annars går ändläget inte att nå. Den
+      // lilla marginalen fångar flyttalsfel, så att ett spår som går jämnt upp
+      // inte får en extra punkt som pekar på samma läge som den föregående.
       const step = reviewStep(track);
-      reviewPageCount.value = step > 0 ? Math.round(maxScroll / step) + 1 : 0;
-      activeReviewIndex.value = step > 0 ? Math.round(track.scrollLeft / step) : 0;
+      const steps = step > 0 ? maxScroll / step : 0;
+      const pageCount = step > 0 ? Math.ceil(steps - 0.02) + 1 : 0;
+      reviewPageCount.value = pageCount;
+
+      // Sista punkten motsvarar maxScroll, som kan ligga närmare föregående
+      // steg än ett helt steg bort. Därför klampas ändläget explicit.
+      activeReviewIndex.value =
+        step <= 0
+          ? 0
+          : track.scrollLeft >= maxScroll - 8
+            ? pageCount - 1
+            : Math.min(Math.round(track.scrollLeft / step), pageCount - 1);
     };
 
     // Scroll-eventet kan komma flera gånger per bildruta. Mätningen läser

--- a/src/components/LandingComponent.vue
+++ b/src/components/LandingComponent.vue
@@ -124,17 +124,57 @@
         <p class="section-text">
           Riktiga omdömen från kunder som bokat fönsterputs i Stockholm. Vill du läsa fler eller lämna ett eget omdöme hittar du Rutputs på Google.
         </p>
-        <div class="review-grid q-mt-lg">
-          <article v-for="review in reviewsData.reviews" :key="review.author + review.date" class="review-card">
-            <div class="review-card__stars" role="img" :aria-label="review.rating + ' av 5 stjärnor'">
-              <span v-for="n in review.rating" :key="n" aria-hidden="true">★</span>
+        <div class="review-carousel q-mt-lg" role="group" aria-roledescription="karusell" aria-label="Kundomdömen">
+          <div
+            ref="reviewTrack"
+            class="review-carousel__track"
+            tabindex="0"
+            @scroll.passive="measureReviews"
+          >
+            <article v-for="review in reviewsData.reviews" :key="review.author + review.date" class="review-card">
+              <div class="review-card__stars" role="img" :aria-label="review.rating + ' av 5 stjärnor'">
+                <span v-for="n in review.rating" :key="n" aria-hidden="true">★</span>
+              </div>
+              <p class="review-card__text">&ldquo;{{ review.text }}&rdquo;</p>
+              <p class="review-card__meta">
+                <strong>{{ review.author }}</strong>
+                <span v-if="review.area"> &middot; {{ review.area }}</span>
+              </p>
+            </article>
+          </div>
+
+          <div v-show="reviewsOverflow" class="review-carousel__controls">
+            <button
+              type="button"
+              class="review-carousel__arrow"
+              :disabled="!canScrollReviewsPrev"
+              aria-label="Visa föregående omdöme"
+              @click="scrollReviews(-1)"
+            >
+              &#8249;
+            </button>
+            <div class="review-carousel__dots">
+              <button
+                v-for="index in reviewPageCount"
+                :key="'dot-' + index"
+                type="button"
+                class="review-carousel__dot"
+                :class="{ 'review-carousel__dot--active': index - 1 === activeReviewIndex }"
+                :aria-label="'Gå till position ' + index + ' av ' + reviewPageCount"
+                :aria-current="index - 1 === activeReviewIndex ? 'true' : undefined"
+                @click="goToReview(index - 1)"
+              />
             </div>
-            <p class="review-card__text">&ldquo;{{ review.text }}&rdquo;</p>
-            <p class="review-card__meta">
-              <strong>{{ review.author }}</strong>
-              <span v-if="review.area"> &middot; {{ review.area }}</span>
-            </p>
-          </article>
+            <button
+              type="button"
+              class="review-carousel__arrow"
+              :disabled="!canScrollReviewsNext"
+              aria-label="Visa nästa omdöme"
+              @click="scrollReviews(1)"
+            >
+              &#8250;
+            </button>
+          </div>
         </div>
         <div class="hero-actions q-pt-md">
           <a :href="reviewsData.googleBusinessUrl" target="_blank" rel="noopener" class="text-accent text-weight-bold">
@@ -338,7 +378,7 @@ export default defineComponent({
           },
           review: reviewsData.reviews.map((r) => ({
             '@type': 'Review',
-            author: { '@type': 'Person', name: r.author },
+            author: { '@type': r.authorType ?? 'Person', name: r.author },
             datePublished: r.date,
             reviewBody: r.text,
             reviewRating: {
@@ -386,6 +426,68 @@ export default defineComponent({
 
     const pickRandomImage = (images: string[]) => images[Math.floor(Math.random() * images.length)];
 
+    // Omdömeskarusellen är en native scroll-container med scroll-snap, så
+    // korten går att svepa mellan även utan JS. Pilarna och punkterna nedan
+    // är bara ett tillgängligt komplement som döljs när allt redan får plats.
+    const reviewTrack = ref<HTMLElement | null>(null);
+    const reviewsOverflow = ref(false);
+    const activeReviewIndex = ref(0);
+    const reviewPageCount = ref(0);
+    const canScrollReviewsPrev = ref(false);
+    const canScrollReviewsNext = ref(false);
+
+    // Ett "steg" är ett kort plus mellanrummet till nästa kort.
+    const reviewStep = (track: HTMLElement) => {
+      const card = track.querySelector<HTMLElement>('.review-card');
+      if (!card) {
+        return 0;
+      }
+      const gap = parseFloat(window.getComputedStyle(track).columnGap) || 0;
+      return card.offsetWidth + gap;
+    };
+
+    const measureReviews = () => {
+      const track = reviewTrack.value;
+      if (!track) {
+        return;
+      }
+
+      // Tolerans på 8px så att avrundning i webbläsarens scrollbredd inte
+      // lämnar en pil aktiv i änden av listan.
+      const maxScroll = track.scrollWidth - track.clientWidth;
+      reviewsOverflow.value = maxScroll > 8;
+      canScrollReviewsPrev.value = track.scrollLeft > 8;
+      canScrollReviewsNext.value = track.scrollLeft < maxScroll - 8;
+
+      // Punkterna motsvarar nåbara scrollpositioner, inte antalet kort. Visas
+      // tre kort samtidigt finns bara tre positioner att gå till, och då ska
+      // det vara tre punkter – annars pekar de sista punkterna på samma läge.
+      const step = reviewStep(track);
+      reviewPageCount.value = step > 0 ? Math.round(maxScroll / step) + 1 : 0;
+      activeReviewIndex.value = step > 0 ? Math.round(track.scrollLeft / step) : 0;
+    };
+
+    const scrollBehavior = (): ScrollBehavior =>
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
+
+    const scrollReviews = (direction: number) => {
+      const track = reviewTrack.value;
+      if (!track) {
+        return;
+      }
+      track.scrollBy({ left: direction * reviewStep(track), behavior: scrollBehavior() });
+    };
+
+    const goToReview = (index: number) => {
+      const track = reviewTrack.value;
+      if (!track) {
+        return;
+      }
+      const maxScroll = track.scrollWidth - track.clientWidth;
+      const left = Math.min(index * reviewStep(track), maxScroll);
+      track.scrollTo({ left, behavior: scrollBehavior() });
+    };
+
     const updateParallax = () => {
       if (typeof window === 'undefined' || !heroSection.value) {
         return;
@@ -413,6 +515,13 @@ export default defineComponent({
       });
     };
 
+    // Kortbredden ändras med brytpunkterna, så karusellen måste mätas om
+    // vid resize för att pilarna ska stämma.
+    const onResize = () => {
+      scheduleParallaxUpdate();
+      measureReviews();
+    };
+
     onMounted(() => {
       randomLandscapeImage.value = pickRandomImage(landscapeImages);
       // Defer portrait randomization until the browser is idle (after initial
@@ -428,15 +537,16 @@ export default defineComponent({
         portraitTimerId = setTimeout(randomizePortrait, 3000);
       }
       updateParallax();
+      measureReviews();
 
       window.addEventListener('scroll', scheduleParallaxUpdate, { passive: true });
-      window.addEventListener('resize', scheduleParallaxUpdate, { passive: true });
+      window.addEventListener('resize', onResize, { passive: true });
     });
 
     onBeforeUnmount(() => {
       if (typeof window !== 'undefined') {
         window.removeEventListener('scroll', scheduleParallaxUpdate);
-        window.removeEventListener('resize', scheduleParallaxUpdate);
+        window.removeEventListener('resize', onResize);
       }
 
       if (animationFrameId) {
@@ -464,7 +574,16 @@ export default defineComponent({
       heroMediaStyle,
       heroSection,
       randomLandscapeImage,
-      randomPortraitImage
+      randomPortraitImage,
+      reviewTrack,
+      reviewsOverflow,
+      activeReviewIndex,
+      reviewPageCount,
+      canScrollReviewsPrev,
+      canScrollReviewsNext,
+      measureReviews,
+      scrollReviews,
+      goToReview
     };
   },
   methods: {
@@ -480,22 +599,33 @@ export default defineComponent({
   will-change: transform;
 }
 
-.review-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+/* Sektionen är ett grid-item och karusellspåret ett flex-item. Utan min-width: 0
+   ärver de min-width: auto, och då kan de inte krympa under spårets max-content
+   (summan av alla kort). Sidan får då horisontell scroll på mobil. */
+.reviews-shell,
+.review-carousel {
+  min-width: 0;
+}
+
+.review-carousel__track {
+  display: flex;
   gap: 1rem;
+  min-width: 0;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
 
-@media (max-width: 1023px) {
-  .review-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.review-carousel__track::-webkit-scrollbar {
+  display: none;
 }
 
-@media (max-width: 599px) {
-  .review-grid {
-    grid-template-columns: 1fr;
-  }
+/* Inåtvänd fokusring – overflow-containern skulle klippa en utåtvänd. */
+.review-carousel__track:focus-visible {
+  outline: 2px solid #C04D00;
+  outline-offset: -2px;
+  border-radius: 0.75rem;
 }
 
 .review-card {
@@ -506,6 +636,103 @@ export default defineComponent({
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  /* Tre kort i bredd på desktop, minus de två mellanrummen. */
+  flex: 0 0 calc((100% - 2rem) / 3);
+  scroll-snap-align: start;
+}
+
+@media (max-width: 1023px) {
+  .review-card {
+    flex-basis: calc((100% - 1rem) / 2);
+  }
+}
+
+@media (max-width: 599px) {
+  /* Nästa kort tittar fram i kanten så att det syns att listan går att svepa. */
+  .review-card {
+    flex-basis: 85%;
+  }
+}
+
+.review-carousel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.review-carousel__arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: inherit;
+  background: transparent;
+  border: 1px solid rgba(69, 90, 100, 0.28);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.review-carousel__arrow:hover:not(:disabled) {
+  background: rgba(69, 90, 100, 0.08);
+  border-color: rgba(69, 90, 100, 0.45);
+}
+
+.review-carousel__arrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.review-carousel__dots {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.review-carousel__dot {
+  /* 24px träffyta runt en 8px prick, så den går att träffa på mobil. */
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.review-carousel__dot::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.3;
+  transition: background-color 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+}
+
+.review-carousel__dot:hover::before {
+  opacity: 0.55;
+}
+
+.review-carousel__dot--active::before {
+  background: #C04D00;
+  opacity: 1;
+  transform: scale(1.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-carousel__arrow,
+  .review-carousel__dot::before {
+    transition: none;
+  }
 }
 
 .review-card__stars {

--- a/src/components/LandingComponent.vue
+++ b/src/components/LandingComponent.vue
@@ -147,7 +147,6 @@
             <button
               type="button"
               class="review-carousel__arrow"
-              :disabled="!canScrollReviewsPrev"
               aria-label="Visa föregående omdöme"
               @click="scrollReviews(-1)"
             >
@@ -168,7 +167,6 @@
             <button
               type="button"
               class="review-carousel__arrow"
-              :disabled="!canScrollReviewsNext"
               aria-label="Visa nästa omdöme"
               @click="scrollReviews(1)"
             >
@@ -434,8 +432,6 @@ export default defineComponent({
     const reviewsOverflow = ref(false);
     const activeReviewIndex = ref(0);
     const reviewPageCount = ref(0);
-    const canScrollReviewsPrev = ref(false);
-    const canScrollReviewsNext = ref(false);
 
     // Ett "steg" är ett kort plus mellanrummet till nästa kort. Kortbredden är
     // procentuell och ändras bara när spåret gör det, så värdet cachas i
@@ -462,11 +458,9 @@ export default defineComponent({
       }
 
       // Tolerans på 8px så att avrundning i webbläsarens scrollbredd inte
-      // lämnar en pil aktiv i änden av listan.
+      // visar kontroller för ett spår som egentligen får plats.
       const maxScroll = track.scrollWidth - track.clientWidth;
       reviewsOverflow.value = maxScroll > 8;
-      canScrollReviewsPrev.value = track.scrollLeft > 8;
-      canScrollReviewsNext.value = track.scrollLeft < maxScroll - 8;
 
       // Punkterna motsvarar nåbara scrollpositioner, inte antalet kort. Visas
       // tre kort samtidigt finns bara tre positioner att gå till, och då ska
@@ -497,7 +491,28 @@ export default defineComponent({
       if (!track) {
         return;
       }
-      track.scrollBy({ left: direction * reviewStep(track), behavior: scrollBehavior() });
+
+      const step = reviewStep(track);
+      if (step <= 0) {
+        return;
+      }
+
+      // Vid ändarna går karusellen runt i stället för att ta stopp. Hoppet
+      // tillbaka görs utan mjuk scroll: en mjuk scroll hela vägen vore en lång
+      // åktur förbi varje kort, och läsaren tappar bort var hen hamnade.
+      const maxScroll = track.scrollWidth - track.clientWidth;
+
+      if (direction > 0 && track.scrollLeft >= maxScroll - 8) {
+        track.scrollTo({ left: 0, behavior: 'auto' });
+        return;
+      }
+
+      if (direction < 0 && track.scrollLeft <= 8) {
+        track.scrollTo({ left: maxScroll, behavior: 'auto' });
+        return;
+      }
+
+      track.scrollBy({ left: direction * step, behavior: scrollBehavior() });
     };
 
     const goToReview = (index: number) => {
@@ -606,8 +621,6 @@ export default defineComponent({
       reviewsOverflow,
       activeReviewIndex,
       reviewPageCount,
-      canScrollReviewsPrev,
-      canScrollReviewsNext,
       scheduleReviewMeasure,
       scrollReviews,
       goToReview
@@ -706,15 +719,11 @@ export default defineComponent({
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-.review-carousel__arrow:hover:not(:disabled) {
+.review-carousel__arrow:hover {
   background: rgba(69, 90, 100, 0.08);
   border-color: rgba(69, 90, 100, 0.45);
 }
 
-.review-carousel__arrow:disabled {
-  opacity: 0.35;
-  cursor: default;
-}
 
 .review-carousel__dots {
   display: flex;

--- a/src/data/business.js
+++ b/src/data/business.js
@@ -27,13 +27,9 @@ const business = {
     latitude: 59.4233,
     longitude: 17.8357,
   },
-  // Aggregerat betyg – enda källa, läses av både UI (reviews.ts) och schema.
-  // reviewCount måste matcha antalet omdömen i reviews-content.js, annars
-  // stämmer inte den strukturerade datan med det som visas på sidan.
-  aggregateRating: {
-    ratingValue: 5.0,
-    reviewCount: 5,
-  },
+  // Aggregerat betyg härleds från omdömeslistan i reviews-content.js och bor
+  // därför inte här – se ratingValue och reviewCount i den filen.
+
   // Profiler som binder ihop Rutputs som en igenkänd entitet (sameAs).
   googleBusinessUrl:
     'https://www.google.com/search?q=Rutputs&stick=H4sIAAAAAAAAAONgU1I1qDAxM7U0SDNONDQ1SDUxSkqzMqgwNzExMzdITDa1NLRMNTQyWsTKHlRaUlBaUgwAQ7U7RjMAAAA&mat=CajQ30ohy9Xe',

--- a/src/data/business.js
+++ b/src/data/business.js
@@ -28,9 +28,11 @@ const business = {
     longitude: 17.8357,
   },
   // Aggregerat betyg – enda källa, läses av både UI (reviews.ts) och schema.
+  // reviewCount måste matcha antalet omdömen i reviews-content.js, annars
+  // stämmer inte den strukturerade datan med det som visas på sidan.
   aggregateRating: {
     ratingValue: 5.0,
-    reviewCount: 2,
+    reviewCount: 5,
   },
   // Profiler som binder ihop Rutputs som en igenkänd entitet (sameAs).
   googleBusinessUrl:

--- a/src/data/reviews-content.js
+++ b/src/data/reviews-content.js
@@ -1,0 +1,43 @@
+// Kundomdömen hämtade från Google Business-profilen för Rutputs.
+// Plain JS så att listan kan läsas både av Vue-appen (reviews.ts) och av
+// Node-prerenderskriptet (scripts/prerender-routes.mjs).
+//
+// Texterna är ordagranna citat och ska inte redigeras – hämta nya omdömen
+// från Google i stället. Listan ligger nyast först; nya omdömen läggs överst.
+// Datumen är ungefärliga när Google bara visar ålder i veckor.
+
+const reviews = [
+  {
+    author: 'Birgitta Kaasik',
+    rating: 5,
+    text: 'Superduktig fönsterputsare . Nu blänkande fönster . Tack !',
+    date: '2026-06-14',
+  },
+  {
+    author: 'Gylle Tandvård',
+    authorType: 'Organization',
+    rating: 5,
+    text: 'Smidigt samarbete och väl utfört jobb.',
+    date: '2026-05-31',
+  },
+  {
+    author: 'Linda',
+    rating: 5,
+    text: 'Toppen! Är supernöjd med fönsterputsningen🌟 Dessutom väldigt bra pris!',
+    date: '2026-05-24',
+  },
+  {
+    author: 'Ulla S.',
+    rating: 5,
+    text: 'Aldrig haft så fina fönster tidigare.',
+    date: '2026-04-25',
+  },
+  {
+    author: 'Delina Le Nguyen',
+    rating: 5,
+    text: 'Jättenoga putsade. Det blev mycket rent och snyggt. Tack för det!',
+    date: '2026-04-25',
+  },
+];
+
+export default reviews;

--- a/src/data/reviews-content.js
+++ b/src/data/reviews-content.js
@@ -40,4 +40,18 @@ const reviews = [
   },
 ];
 
+// Det aggregerade betyget härleds från listan ovan i stället för att skrivas
+// in för hand. Annars kan reviewCount hamna ur synk med antalet Review-noder
+// i den strukturerade datan, och då motsäger markupen sig själv.
+//
+// Vill du någon gång låta aggregatet spegla alla omdömen på Google i stället
+// för de som listas här, sätt värdena manuellt – men lägg då till omdömena i
+// listan också, annars är det just den motsägelsen som uppstår.
+export const reviewCount = reviews.length;
+
+export const ratingValue =
+  reviews.length > 0
+    ? Number((reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length).toFixed(1))
+    : 0;
+
 export default reviews;

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -1,5 +1,5 @@
 import business from './business.js';
-import reviewsList from './reviews-content.js';
+import reviewsList, { ratingValue, reviewCount } from './reviews-content.js';
 
 export interface Review {
   author: string;
@@ -19,8 +19,8 @@ export interface ReviewsData {
 }
 
 export const reviewsData: ReviewsData = {
-  aggregateRating: business.aggregateRating.ratingValue,
-  reviewCount: business.aggregateRating.reviewCount,
+  aggregateRating: ratingValue,
+  reviewCount,
   googleBusinessUrl: business.googleBusinessUrl,
   reviews: reviewsList as Review[],
 };

--- a/src/data/reviews.ts
+++ b/src/data/reviews.ts
@@ -1,7 +1,10 @@
 import business from './business.js';
+import reviewsList from './reviews-content.js';
 
 export interface Review {
   author: string;
+  /** Schema.org-typ för recensenten. Företagskunder ska vara 'Organization'. */
+  authorType?: 'Person' | 'Organization';
   rating: number;
   text: string;
   date: string;
@@ -19,18 +22,5 @@ export const reviewsData: ReviewsData = {
   aggregateRating: business.aggregateRating.ratingValue,
   reviewCount: business.aggregateRating.reviewCount,
   googleBusinessUrl: business.googleBusinessUrl,
-  reviews: [
-    {
-      author: 'Ulla S.',
-      rating: 5,
-      text: 'Aldrig haft så fina fönster tidigare.',
-      date: '2026-04-25',
-    },
-    {
-      author: 'Delina Le Nguyen',
-      rating: 5,
-      text: 'Jättenoga putsade. Det blev mycket rent och snyggt. Tack för det!',
-      date: '2026-04-25',
-    },
-  ],
+  reviews: reviewsList as Review[],
 };


### PR DESCRIPTION
## Sammanfattning

Omdömessektionen på startsidan visade två omdömen i ett statiskt rutnät. Nu finns fem, och listan växer, så rutnätet ersätts med en karusell.

## Data

Underlaget var fyra skärmbilder från Google-profilen. En av dem, Ulla S., låg redan i `reviews.ts` sedan tidigare, så **tre omdömen är nya**: Birgitta Kaasik, Gylle Tandvård och Linda. Tillsammans med Ulla S. och Delina Le Nguyen blir det fem totalt.

Texterna är **ordagranna citat** och ska inte redigeras – hämta nya från Google i stället.

| Kund | Betyg | Datum | |
| --- | --- | --- | --- |
| Birgitta Kaasik | 5 | 2026-06-14 | ny |
| Gylle Tandvård | 5 | 2026-05-31 | ny |
| Linda | 5 | 2026-05-24 | ny |
| Ulla S. | 5 | 2026-04-25 | fanns |
| Delina Le Nguyen | 5 | 2026-04-25 | fanns |

Datumen är ungefärliga: Google visar bara ålder i veckor, så de är framräknade därifrån.

- Listan flyttas till `src/data/reviews-content.js`, samma plain-JS-mönster som `business.js` och `guides-content.js` redan använder, så att både Vue-appen och Node-prerenderskriptet kan läsa den. `reviews.ts` exponerar den vidare till appen.
- `reviewCount` och `ratingValue` **härleds** från listan och exporteras från samma fil, så att appen och prerendern räknar likadant och antalet aldrig kan hamna ur synk med antalet `Review`-noder i samma JSON-LD-block. `aggregateRating` är därmed borttagen ur `business.js`, där den inte längre har någon läsare.
- Nytt valfritt fält `authorType`, satt till `Organization` för Gylle Tandvård som är en företagskund. Övriga blir `Person` som tidigare.

## Karusell

- Native scroll-container med `scroll-snap`, så korten går att svepa mellan även utan JS.
- Tre kort på desktop, två på surfplatta, ett med en glimt av nästa på mobil.
- **Går runt vid ändarna:** nästa på sista kortet leder till första och tvärtom, så pilarna tar aldrig stopp. Själva varvningen sker utan mjuk scroll – en mjuk scroll hela vägen tillbaka blir en lång åktur förbi varje kort. Manuellt svep tar fortfarande stopp vid ändarna; att lösa det kräver klonade kort, vilket skulle dubblera omdömestexterna i DOM:en och motverka den strukturerade datan.
- Pilar och punkter döljs helt när alla kort redan får plats.
- Punkterna motsvarar nåbara scrollpositioner, inte antalet kort. Antalet räknas med `ceil` plus en liten marginal, så att både en ojämn sista bit får en egen punkt och ett jämnt uppgående spår slipper en extra punkt på samma läge.
- Scrollmätningen stryps till en gång per bildruta med `requestAnimationFrame` och steglängden cachas, så svep inte tvingar fram layout-läsningar per event.
- Respekterar `prefers-reduced-motion`.

## Två buggar som fångades under arbetet

Båda infördes av den här ändringen och är åtgärdade i samma gren:

- **Horisontell scroll på mobil.** Sektionen är ett grid-item och karusellspåret ett flex-item. Med ärvd `min-width: auto` kunde de inte krympa under spårets max-content, och startsidan blev 749 px bred i en 390 px-vy. Löst med `min-width: 0`. En separat build av `main` bekräftade att overflowet inte fanns sedan tidigare.
- **Osynliga kontroller.** Pilar och punkter ritades först i vit-alpha, vilket inte syns mot den ljusa panelen. De använder nu sidans bläck- och accenttoner.

## SEO

Den prerenderade HTML:en hade `aggregateRating` men inget synligt recensionsinnehåll, eftersom korten renderas klientsida. Prerendern skriver nu ut både en `Kundomdömen`-sektion och `Review`-noder i den strukturerade datan.

## Verifiering

- `npm run lint` – rent (den enda varningen ligger i `src/boot/analytics.ts` och är sedan tidigare).
- `npm run build` – lyckas, 34 SEO-rutter prerenderade.
- Kontrollerat i Chromium på 1280, 900 och 390 px: noll horisontellt överskott, varje punkt leder till ett eget läge, sista punkten landar exakt på maxScroll, klick på punkt *i* tänder punkt *i*, framåt från sista landar på första och bakåt från första på sista, och vid resize räknas steglängden om.
- Strukturerad data i `dist/spa/index.html` granskad: `reviewCount` matchar antalet `Review`-noder och `ratingValue` matchar snittet av dem.

**Kvar för manuell koll:** svep och scroll-snap i Safari/iOS, som är där beteendet historiskt skiljer sig mest från Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekjv9D4545qfYSgLe8KC6j